### PR TITLE
Close files to fix "Error 32: Files in use" error

### DIFF
--- a/GroovyRP/GrooveInfoFetcher.cs
+++ b/GroovyRP/GrooveInfoFetcher.cs
@@ -51,6 +51,8 @@ namespace GroovyRP
                     return result;
                 }
             }
+            csvParser.Dispose();
+            streamReader.Dispose();
             return result;
         }
 

--- a/README.MD
+++ b/README.MD
@@ -1,0 +1,16 @@
+## System Requirements:
+
+* Windows 10
+* Groove Music
+* Discord (desktop client only)
+* Administrative rights
+## How to Use:
+
+* Download and extract GroovyRP.zip.
+* Run GroovyRP.exe.
+* Administrative rights are required due to reliance on OpenedFilesView to figure out what Groove Music is accessing.
+
+### Changes since last version:
+
+* Added better error handling
+* Switched to CsvHelper library


### PR DESCRIPTION
When I ran this out-of-the-box, I was getting an error involving files left open. After applying a small patch, it largely fixed itself. Also, I completely overhauled the music detection on my own repository. I think it is genius the setup you have going, although it took too many resources to be viable imo so I set out to, and successfully reduced impact.